### PR TITLE
feat: Note Editor Page.  Markdown editor with live preview, formatting toolbar, and mobile responsive layout

### DIFF
--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -290,3 +290,69 @@
     flex-basis:  100%;
 }
 .tag-input::placeholder { color: var(--text-muted); }
+
+
+/* Toolbar */
+.md-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--editor-box-border);
+    
+}
+
+.tb-btn {
+    width: 30px;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: var(--tb-btn-color);
+    cursor: pointer;
+    font-size: 13px;
+    font-family: var(--font);
+    transition: background 0.15s, color 0.15s;
+
+    /* needed for tooltip */
+    position: relative;
+}
+
+.tb-btn:hover {
+    background: var(--nav-active-bg);
+    color: var(--text-primary);
+    border-color: var(--editor-box-border);
+}
+.tb-sep {
+    width: 1px;
+    height: 20px;
+    background: var(--sidebar-divider);
+    margin: 0 3px;
+    flex-shrink: 0;
+}
+
+.tb-btn::after {
+    content: attr(data-tip);
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--tb-tooltip-bg);
+    border: 1px solid var(--editor-box-border);
+    color: var(--text-primary);
+    font-size: 10px;
+    font-family: var(--font);
+    padding: 3px 8px;
+    border-radius: 6px;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.1s;
+    z-index: 10;
+}
+.tb-btn:hover::after { 
+    opacity: 1; 
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -1,0 +1,192 @@
+.editor-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.editor-header-left {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.editor-title {
+    outline: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.2s;
+    cursor: text;
+    margin-bottom: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 500px;
+}
+
+.editor-title:focus {
+    border-color: var(--editor-box-border);
+}
+
+.editor-header-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.view-toggle {
+    display: flex;
+    align-items: center;
+    background: var(--sidebar-bg);
+    border: 1px solid var(--sidebar-border);
+    border-radius: 12px;
+    padding: 4px;
+    gap: 0;
+    backdrop-filter: blur(10px);
+}
+
+.view-toggle-divider {
+    width: 1px;
+    height: 18px;
+    background: var(--sidebar-divider);
+    flex-shrink: 0;
+    margin-left: 5px;
+    margin-right: 5px;
+}
+
+.view-btn {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 7px 12px;
+    border-radius: 8px;
+    font-family: var(--font);
+    font-size: 12px;
+    font-weight: 300;
+    color: var(--nav-icon-color);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    white-space: nowrap;
+}
+
+.view-btn:hover {
+    color: var(--text-primary);
+}
+
+.view-btn.active {
+    background: var(--nav-active-bg);
+    color: var(--nav-active-icon);
+}
+
+.btn-save {
+    padding: 8px 20px;
+    border-radius: 10px;
+    background: var(--btn-green-bg);
+    border: 1px solid var(--btn-green-border);
+    color: var(--btn-green-color);
+    font-family: var(--font);
+    font-size: 13px;
+    font-weight: 400;
+    cursor: pointer;
+    transition: background 0.2s;
+    white-space: nowrap;
+}
+
+.btn-save:hover {
+    background: var(--btn-green-bg-hover);
+}
+
+/* editor layout */
+.editor-layout {
+    display: flex;
+    gap: 16px;
+    flex: 1;
+    overflow: hidden;
+}
+
+.editor-box {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    background: var(--editor-box-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+
+.editor-side {
+    width: 220px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    overflow-y: auto;
+    scrollbar-width: none;
+}
+.editor-side::-webkit-scrollbar { display: none; }
+
+
+.editor-side-card {
+    background: var(--side-card-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 14px;
+    padding: 14px;
+    flex-shrink: 0;
+}
+
+.editor-side-label {
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+}
+
+
+.btn-quiz {
+    width: 100%;
+    padding: 9px;
+    border-radius: 10px;
+    background: var(--btn-green-bg);
+    border: 1px solid var(--btn-green-border);
+    color: var(--btn-green-color);
+    font-family: var(--font);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.btn-quiz:hover { background: var(--btn-green-bg-hover); }
+
+.quiz-disclaimer {
+    font-size: 10px;
+    color: var(--text-muted);
+    line-height: 1.5;
+}
+
+.btn-danger {
+    width: 100%;
+    padding: 9px;
+    border-radius: 10px;
+    background: var(--btn-danger-bg);
+    border: 1px solid var(--btn-danger-border);
+    color: var(--btn-danger-color);
+    font-family: var(--font);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+.btn-danger:hover { background: var(--btn-danger-bg-hover); }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -10,6 +10,7 @@
     flex-direction: column;
     gap: 2px;
     min-width: 0;
+    overflow: hidden;
 }
 
 .editor-title {
@@ -21,7 +22,8 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 500px;
+    max-width: 100%;
+    /* background-color: blueviolet; */
 }
 
 .editor-title:focus {
@@ -245,3 +247,46 @@
 .side-textarea::placeholder { 
     color: var(--text-muted); 
 }
+
+
+.tags-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    align-items: center;
+    cursor: text;
+    min-height: 28px;
+}
+
+.tag-removable {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.tag-remove {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 12px;
+    padding: 0;
+    line-height: 1;
+    transition: color 0.15s;
+}
+.tag-remove:hover { color: var(--text-primary); }
+
+.tag-input {
+    background: transparent;
+    border: none;
+    outline: none;
+    font-family: var(--font);
+    font-size: 11px;
+    color: var(--text-primary);
+    min-width: 60px;
+    flex: 1;
+    margin-top: 10px;
+    /* this tells flex container to let this item get a full row */
+    flex-basis:  100%;
+}
+.tag-input::placeholder { color: var(--text-muted); }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -838,3 +838,14 @@ body.mode-preview .md-preview {
 
 .md-preview::-webkit-scrollbar { display: none; }
 .md-preview { scrollbar-width: none; }
+
+
+.btn-save.unsaved {
+    background: var(--btn-danger-bg);
+    border-color: var(--btn-danger-border);
+    color: var(--btn-danger-color);
+}
+
+.btn-save.unsaved:hover {
+    background: var(--btn-danger-bg-hover);
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -28,6 +28,8 @@
 
 .editor-title:focus {
     border-color: var(--editor-box-border);
+    overflow-x: auto;
+    text-overflow: clip;
 }
 
 .editor-header-right {
@@ -558,6 +560,15 @@ body.mode-preview .md-preview {
     .tb-btn::after {
         display: none;
     }
+
+    .editor-title {
+        width: 100%;
+        max-width: 100%;
+    }
+    .editor-header-left {
+        width: 100%;
+    }
+
 }
 
 /* Preview Text Stylings*/

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -477,3 +477,65 @@ body.mode-preview .md-preview {
 body.mode-preview .write-label { 
     display: none; 
 }
+
+@media (max-width: 900px) {
+
+    .dash-container {
+        overflow-y: auto;
+        height: 100%;
+        scrollbar-width: none;
+    }
+    .dash-container::-webkit-scrollbar {
+        display: none;
+    }
+
+    .editor-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+
+    .editor-header-right {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .editor-layout {
+        flex-direction: column;
+        overflow: visible;
+    }
+
+    .editor-side {
+        width: 100%;
+        overflow-y: visible;
+    }
+
+    .pane-divider {
+        display: none !important;
+    }
+
+    .md-textarea {
+        display: block;
+        flex: 1;
+        min-height: 500px;
+    }
+
+    body.mode-preview .md-preview {
+        display: block;
+        flex: 1;
+        min-height: 500px;
+    }
+
+    body.mode-preview .md-textarea {
+        display: none;
+    }
+
+    #btn-split,
+    #divider-left{
+        display: none;
+    }
+
+    .dash-divider {
+        margin-top: 15px;
+    }
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -428,6 +428,7 @@
     overflow-y: auto;
     padding: 32px 16px 16px;
     display: none;
+    font-family: var(--font)
 }
 
 /* Views */
@@ -557,4 +558,21 @@ body.mode-preview .write-label {
     .tb-btn::after {
         display: none;
     }
+}
+
+/* Preview Text Stylings*/
+/* plain text */
+.md-preview p { 
+    color: var(--text-muted); 
+    font-size: 13px; 
+    line-height: 1.7; 
+    margin-bottom: 0.8em; 
+    font-family: var(--font);
+    font-weight: 100;
+}
+
+/* bold text */
+.md-preview strong { 
+    color: var(--text-primary); 
+    font-weight: 600; 
 }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -543,4 +543,15 @@ body.mode-preview .write-label {
     .editor-pane-right {
         display: none;
     }
+
+    .md-toolbar {
+        overflow-x: auto;
+        scrollbar-width: none;
+        flex-wrap: nowrap;
+        gap: 15px;
+    }
+
+    .md-toolbar::-webkit-scrollbar {
+        display: none;
+    }
 }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -610,3 +610,42 @@ body.mode-preview .write-label {
     margin: 0 0 0.8em;
     font-family: var(--font);
 }
+
+
+.md-preview code {
+    background: var(--preview-code-bg);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    color: var(--preview-code-color);
+}
+.md-preview pre {
+    background: var(--preview-pre-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 8px;
+    padding: 12px;
+    overflow-x: auto;
+    margin-bottom: 1em;
+}
+.md-preview pre code { 
+    background: transparent; 
+    padding: 5px; 
+}
+.md-preview hr { 
+    border: none; 
+    border-top: 1px solid var(--editor-box-border); 
+    margin: 1em 0; 
+}
+
+
+
+.md-preview a {
+    color: var(--text-muted);
+    text-decoration: underline;
+}
+
+.md-preview a:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -190,3 +190,40 @@
     gap: 6px;
 }
 .btn-danger:hover { background: var(--btn-danger-bg-hover); }
+
+.vis-toggle {
+    display: flex;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    border-radius: 10px;
+    padding: 3px;
+    gap: 3px;
+}
+
+.vis-btn {
+    flex: 1;
+    padding: 6px 0;
+    border-radius: 7px;
+    font-size: 11px;
+    font-family: var(--font);
+    text-align: center;
+    cursor: pointer;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    background: transparent;
+    transition: background 0.15s, color 0.15s;
+    margin: 2px;
+}
+
+.vis-btn.active {
+    background: var(--nav-active-bg);
+    border-color: var(--editor-box-border);
+    color: var(--text-primary);
+}
+.vis-divider {
+    width: 1px;
+    background: var(--sidebar-divider);
+    align-self: stretch;
+    margin-left: 2px;
+    margin-right: 2px;
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -863,3 +863,14 @@ body.mode-preview .md-preview {
 .btn-save.unsaved:hover {
     background: var(--btn-danger-bg-hover);
 }
+
+.back-btn {
+    color: var(--text-muted);
+    text-decoration: none;
+    margin-right: 6px;
+    transition: color 0.15s;
+}
+
+.back-btn:hover {
+    color: var(--text-primary);
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -594,3 +594,19 @@ body.mode-preview .write-label {
     font-size: 17px; 
     font-weight: 400;
 }
+
+
+.md-preview ul, .md-preview ol {
+    color: var(--text-muted);
+    font-size: 13px;
+    padding-left: 20px;
+    margin-bottom: 0.8em;
+    font-family: var(--font);
+}
+.md-preview blockquote {
+    border-left: 3px solid var(--editor-box-border);
+    padding-left: 14px;
+    color: var(--text-muted);
+    margin: 0 0 0.8em;
+    font-family: var(--font);
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -574,5 +574,23 @@ body.mode-preview .write-label {
 /* bold text */
 .md-preview strong { 
     color: var(--text-primary); 
-    font-weight: 600; 
+    font-weight: 400; 
+}
+
+.md-preview h1, .md-preview h2, .md-preview h3 {
+    color: var(--text-primary);
+    
+    margin: 0.8em 0 0.4em;
+}
+.md-preview h1 { 
+    font-size: 24px; 
+    font-weight: 800;
+}
+.md-preview h2 { 
+    font-size: 20px; 
+    font-weight: 600;
+}
+.md-preview h3 { 
+    font-size: 17px; 
+    font-weight: 400;
 }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -367,7 +367,7 @@
     position: relative;
 }
 
-.editor-pane-label {
+/* .editor-pane-label {
     position: absolute;
     top: 10px;
     font-size: 11px;
@@ -375,7 +375,7 @@
     color: var(--text-muted);
     pointer-events: none;
     z-index: 1;
-}
+} */
 
 /* .write-label { 
     left: 16px; 
@@ -389,9 +389,9 @@
     position: relative;
 }
 
-.preview-label, .write-label { 
+/* .preview-label, .write-label { 
     left: 16px; 
-}
+} */
 
 /* Textarea */
 .md-textarea {
@@ -405,7 +405,7 @@
     font-family: 'DM Mono', 'Courier New', monospace;
     font-size: 13px;
     line-height: 1.8;
-    padding: 32px 16px 16px;
+    padding: 16px 16px 16px;
     caret-color: var(--editor-caret);
 }
 
@@ -426,7 +426,7 @@
     flex: 1;
     min-width: 0;
     overflow-y: auto;
-    padding: 32px 16px 16px;
+    padding: 16px 16px 16px;
     display: none;
     font-family: var(--font)
 }
@@ -475,9 +475,9 @@ body.mode-preview .md-preview {
     display: block; 
     flex: 1; 
 }
-body.mode-preview .write-label { 
+/* body.mode-preview .write-label { 
     display: none; 
-}
+} */
 
 @media (max-width: 900px) {
 
@@ -649,3 +649,192 @@ body.mode-preview .write-label {
     color: var(--text-primary);
     text-decoration: underline;
 }
+
+/* Table in preview stylings */
+.md-preview th, .md-preview td { 
+    border: 1px solid var(--editor-box-border); 
+    padding: 6px 10px; 
+    font-size: 13px; 
+    color: var(--text-muted);
+    font-family: var(--font);
+}
+.md-preview th { 
+    background: var(--preview-pre-bg); 
+    color: var(--text-primary); 
+    white-space: nowrap;
+}
+
+
+/* Table modal */
+#table-modal-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    background: var(--modal-backdrop-bg);
+    backdrop-filter: blur(4px);
+}
+
+
+#table-modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--modal-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 18px;
+    padding: 24px;
+    width: 320px;
+    font-family: var(--font);
+    box-shadow: 0 24px 60px var(--modal-shadow);
+    
+    
+}
+
+.table-modal-title {
+    font-size: 10px;
+    color: var(--modal-title-color);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-bottom: 16px;
+}
+
+.table-modal-section {
+    margin-bottom: 18px;
+}
+
+.table-modal-hint {
+    font-size: 11px;
+    color: var(--modal-hint-color);
+    margin-bottom: 8px;
+}
+
+.table-modal-hint span {
+    color: var(--modal-hint-span-color);
+}
+
+#grid-picker {
+    display: grid;
+    grid-template-columns: repeat(8, 28px);
+    gap: 3px;
+    justify-content: center;
+}
+
+.table-modal-inputs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 18px;
+}
+
+.table-modal-input-group {
+    flex: 1;
+}
+
+.table-modal-input-label {
+    font-size: 10px;
+    color: var(--modal-title-color);
+    margin-bottom: 5px;
+    font-weight: 200;
+}
+
+.table-modal-input-group input {
+    width: 100%;
+    background: var(--modal-input-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 8px;
+    padding: 8px 10px;
+    color: var(--modal-input-color);
+    font-family: var(--font);
+    font-size: 13px;
+    outline: none;
+    font-weight: 100;
+}
+
+/* removes spin buttons from number inputs */
+.table-modal-input-group input::-webkit-inner-spin-button,
+.table-modal-input-group input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+/* same but firefox */
+.table-modal-input-group input[type=number] {
+    -moz-appearance: textfield;
+}
+
+.table-modal-preview {
+    font-size: 10px;
+    color: var(--modal-preview-color);
+    margin-bottom: 16px;
+    line-height: 1.6;
+    font-weight: 100;
+}
+
+.table-modal-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.table-modal-btn-cancel {
+    flex: 1;
+    padding: 10px;
+    border-radius: 10px;
+    background: var(--modal-cancel-bg);
+    border: 1px solid var( --modal-cancel-border);
+    color: var(--modal-cancel-color);
+    font-family: var(--font);
+    font-size: 11px;
+    cursor: pointer;
+    transition: background 0.15s;
+    font-weight: 200;
+}
+
+.table-modal-btn-cancel:hover {
+    background: var(--modal-cancel-bg-hover);
+}
+
+.table-modal-btn-insert {
+    flex: 1;
+    padding: 10px;
+    border-radius: 10px;
+    background: var(--modal-insert-bg);
+    border: 1px solid var(--modal-insert-border);
+    color: var(--modal-insert-color);
+    font-family: var(--font);
+    font-size: 11px;
+    cursor: pointer;
+    transition: background 0.15s;
+     font-weight: 200;
+}
+
+.table-modal-btn-insert:hover {
+    background: var(--modal-insert-bg-hover);
+}
+
+.grid-cell {
+    width: 28px;
+    height: 28px;
+    border-radius: 5px;
+    border: 1px solid var(--editor-box-border);
+    background: var(--grid-cell-bg);
+    cursor: pointer;
+    transition: background 0.1s, border-color 0.1s;
+}
+
+.md-preview table { 
+    border-collapse: collapse; 
+    width: 100%; 
+    margin-bottom: 1em; 
+}
+
+
+
+
+
+.md-textarea::-webkit-scrollbar { display: none; }
+.md-textarea { scrollbar-width: none; }
+
+.md-preview::-webkit-scrollbar { display: none; }
+.md-preview { scrollbar-width: none; }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -554,4 +554,7 @@ body.mode-preview .write-label {
     .md-toolbar::-webkit-scrollbar {
         display: none;
     }
+    .tb-btn::after {
+        display: none;
+    }
 }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -480,6 +480,7 @@ body.mode-preview .write-label {
 
 @media (max-width: 900px) {
 
+
     .dash-container {
         overflow-y: auto;
         height: 100%;
@@ -537,5 +538,9 @@ body.mode-preview .write-label {
 
     .dash-divider {
         margin-top: 15px;
+    }
+
+    .editor-pane-right {
+        display: none;
     }
 }

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -356,3 +356,124 @@
 .tb-btn:hover::after { 
     opacity: 1; 
 }
+
+
+
+.editor-pane {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    overflow: hidden;
+    position: relative;
+}
+
+.editor-pane-label {
+    position: absolute;
+    top: 10px;
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--text-muted);
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* .write-label { 
+    left: 16px; 
+} */
+
+.editor-pane-right {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+}
+
+.preview-label, .write-label { 
+    left: 16px; 
+}
+
+/* Textarea */
+.md-textarea {
+    flex: 1;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    outline: none;
+    resize: none;
+    color: var(--text-primary);
+    font-family: 'DM Mono', 'Courier New', monospace;
+    font-size: 13px;
+    line-height: 1.8;
+    padding: 32px 16px 16px;
+    caret-color: var(--editor-caret);
+}
+
+.md-textarea::placeholder  { 
+    color: var(--text-muted); 
+}
+
+/* Pane divider */
+.pane-divider {
+    width: 1px;
+    background: var(--editor-pane-divider);
+    flex-shrink: 0;
+    height: 95%;
+    align-self: center;
+}
+
+.md-preview {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    padding: 32px 16px 16px;
+    display: none;
+}
+
+/* Views */
+/* Edit View */
+body.mode-edit .md-textarea { 
+    display: block; 
+    flex: 1; 
+}
+body.mode-edit .pane-divider { 
+    display: none; 
+}
+body.mode-edit .editor-pane-right { 
+    display: none; 
+}
+
+/* Split View */
+body.mode-split .md-textarea { 
+    display: block; 
+    flex: 1; 
+}
+body.mode-split .pane-divider { 
+    display: block; 
+}
+body.mode-split .editor-pane-right { 
+    display: flex; 
+}
+body.mode-split .md-preview { 
+    display: block; 
+}
+
+
+/* Preview View */
+body.mode-preview .md-textarea { 
+    display: none; 
+}
+body.mode-preview .pane-divider { 
+    display: none; 
+}
+body.mode-preview .editor-pane-right { 
+    display: flex; 
+    flex: 1; 
+}
+body.mode-preview .md-preview { 
+    display: block; 
+    flex: 1; 
+}
+body.mode-preview .write-label { 
+    display: none; 
+}

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -641,8 +641,11 @@ body.mode-preview .md-preview {
 }
 .md-preview pre code { 
     background: transparent; 
-    padding: 5px; 
+    padding: 0px; 
 }
+
+.md-preview pre::-webkit-scrollbar { display: none; }
+.md-preview pre { scrollbar-width: none; }
 .md-preview hr { 
     border: none; 
     border-top: 1px solid var(--editor-box-border); 

--- a/static/css/editor.css
+++ b/static/css/editor.css
@@ -227,3 +227,21 @@
     margin-left: 2px;
     margin-right: 2px;
 }
+
+.side-textarea {
+    width: 100%;
+    background: transparent;
+    border: none;
+    outline: none;
+    resize: none;
+    color: var(--text-primary);
+    font-family: var(--font);
+    font-size: 12px;
+    font-weight: 300;
+    line-height: 1.6;
+    min-height: 60px;
+}
+
+.side-textarea::placeholder { 
+    color: var(--text-muted); 
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -103,7 +103,7 @@
     /* Preview */
     --preview-code-bg:            rgba(98, 98, 98, 0.2);
     --preview-code-color:         #c8c8c8;
-    --preview-pre-bg:             rgba(32, 32, 32, 0.6);
+    --preview-pre-bg:             rgba(32, 32, 32, 0.5);
 }
 
 body {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -69,9 +69,41 @@
     --tb-btn-color:               #AAAAAA;
     --tb-tooltip-bg:              #1a1a1a;
 
-     --editor-caret:               #aaa;
-     --editor-pane-divider:        #434343;
+    --editor-caret:               #aaa;
+    --editor-pane-divider:        #434343;
 
+
+     /* Table modal */
+    --modal-bg:      rgba(32, 32, 32, 0.20);
+    --modal-shadow:               rgba(0, 0, 0, 0.6);
+    --modal-backdrop-bg:          rgba(0, 0, 0, 0.6);
+    --modal-title-color:          #888;
+    --modal-hint-color:           #666;
+    --modal-hint-span-color:      #aaa;
+    --modal-input-bg:             #1a1a1a;
+    --modal-input-color:          #f0f0f0;
+    --modal-preview-color:        #888;
+
+
+    --modal-cancel-bg:            rgba(200, 60, 60, 0.06);
+    --modal-cancel-bg-hover:      rgba(200, 60, 60, 0.14);
+    --modal-cancel-color:         #cc7070;
+    --modal-cancel-border:        rgba(200, 60, 60, 0.30);
+
+    --modal-insert-bg:            rgba(26, 58, 20, 0.20);
+    --modal-insert-bg-hover:      rgba(26, 58, 20, 0.40);
+    --modal-insert-border:        #5BAE6B;
+    --modal-insert-color:         #5BAE6B;
+
+    /* Grid picker */
+    --grid-cell-bg:               rgba(32, 32, 32, 0.4);
+    --grid-cell-active-bg:        rgba(98, 98, 98, 0.4);
+    --grid-cell-active-border:    rgba(160, 160, 160, 1);
+
+    /* Preview */
+    --preview-code-bg:            rgba(98, 98, 98, 0.2);
+    --preview-code-color:         #c8c8c8;
+    --preview-pre-bg:             rgba(32, 32, 32, 0.6);
 }
 
 body {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -69,6 +69,9 @@
     --tb-btn-color:               #AAAAAA;
     --tb-tooltip-bg:              #1a1a1a;
 
+     --editor-caret:               #aaa;
+     --editor-pane-divider:        #434343;
+
 }
 
 body {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -66,6 +66,8 @@
 
     --side-card-bg:            rgba(32, 32, 32, 0.40);
 
+    --tb-btn-color:               #AAAAAA;
+    --tb-tooltip-bg:              #1a1a1a;
 
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -206,28 +206,45 @@ body::before {
     height: 100%;
 }
 
-
 @media (max-width: 900px) {
+
+
+    body::before {
+        width: 300px;
+        height: 300px;
+        left: 50%;
+        transform: translateX(-50%);
+        top: -50px;
+    }
+
+    .dash-container {
+        width: 100%;
+    }
+
+    .dash-main {
+        width: 100%;
+    }
 
     .dashboard-body {
         padding: 16px;
-        padding-bottom: 100px;
-        height: 100vh;
+        height: 100dvh;
+        display: flex;
+        flex-direction: column;
     }
 
     .sidebar {
         position: fixed;
+        bottom: 16px;
         top: auto;
-        bottom: 20px;
         left: 50%;
         transform: translateX(-50%);
+        flex-direction: row;
         width: auto;
         height: auto;
-        flex-direction: row;
-        align-items: center;
         border-radius: 20px;
-        padding: 10px 10px;
+        padding: 10px;
         gap: 5px;
+        z-index: 100;
     }
 
     .sidebar-divider {
@@ -238,9 +255,24 @@ body::before {
 
     .dash-main {
         margin-left: 0;
-        height: 100%;
-        max-height:calc(100dvh - 120px); ;
+        flex: 1;
+        min-height: 0;
+        height: auto;
+        padding-bottom: 85px;
     }
 
-   
+    .dash-container {
+        height: auto;
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+        scrollbar-width: none;
+    }
+
+    .dash-container::-webkit-scrollbar {
+        display: none;
+    }
+
+    
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -50,6 +50,23 @@
     --deck-progress-bg:    rgba(80, 80, 80, 0.20);
     --deck-progress-fill:  #FFFFFF;
     --deck-progress-text:  #A0A0A0;
+
+    /* Editor */
+    --editor-box-bg:           rgba(32, 32, 32, 0.40);
+    --editor-box-border:       rgba(98, 98, 98, 1);
+
+    --btn-green-bg:            rgba(26, 58, 20, 0.20);
+    --btn-green-bg-hover:      rgba(26, 58, 20, 0.40);
+    --btn-green-border:        #5BAE6B;
+    --btn-green-color:         #5BAE6B;
+    --btn-danger-bg:           rgba(200, 60, 60, 0.06);
+    --btn-danger-bg-hover:     rgba(200, 60, 60, 0.14);
+    --btn-danger-border:       rgba(200, 60, 60, 0.30);
+    --btn-danger-color:        #cc7070;
+
+    --side-card-bg:            rgba(32, 32, 32, 0.40);
+
+
 }
 
 body {

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -101,6 +101,52 @@ function onEdit() {
     renderPreview();
 }
 
-function fmt(type){
+function fmt(type) {
 
+    // we added const textarea earlier (md-input)
+    const el = textarea;
+    // cursor start and end positions
+    const start = el.selectionStart;
+    const end = el.selectionEnd;
+
+    // selected text
+    const sel = el.value.substring(start, end);
+
+    // everything before selected
+    const before = el.value.substring(0, start);
+    // everyting after
+    const after = el.value.substring(end);
+
+    let newText = ''
+    let cursorOffset = 0
+    let selectLen = 0;
+
+    switch (type) {
+        case 'bold':
+            // if text is selected, wrap it. If not, insert placeholder and select it.
+            newText = `**${sel || 'bold text'}**`;
+            cursorOffset = sel ? newText.length : 2 + 9; 
+            selectLen = sel ? 0 : 9;                     
+            break;
+        case 'italic':
+            newText = `*${sel || 'italic text'}*`;
+            cursorOffset = sel ? newText.length : 1 + 11; 
+            selectLen = sel ? 0 : 11;
+            break;
+        case 'strike':
+            newText = `~~${sel || 'strikethrough'}~~`;
+            cursorOffset = sel ? newText.length : 2 + 13; 
+            selectLen = sel ? 0 : 13;
+            break;
+        default:
+            return;
+    }
+    // rebuild textarea with formatted text inserted
+    el.value = before + newText + after;
+    // focus back on textarea and set cursor selection
+    el.focus();
+    el.selectionStart = start + cursorOffset - selectLen;
+    el.selectionEnd = start + cursorOffset;
+    // re render preview
+    onEdit();
 }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -36,3 +36,31 @@ function autoResizeTextarea(element) {
     element.style.height = 'auto';
     element.style.height = element.scrollHeight + 'px';
 }
+
+function handleTag(evnt) {
+
+    if (evnt.key === 'Enter' || evnt.key === ',') {
+        const val = evnt.target.value.trim().replace(/,/g, '').substring(0, 20);
+
+        if (!val) {
+            return;
+        }
+
+        const pill = document.createElement('span');
+        pill.className = 'note-tag tag-removable';
+        pill.innerHTML = `${val} <button class="tag-remove" onclick="removeTag(this)">×</button>`;
+        document.getElementById('tags-wrap').insertBefore(pill, evnt.target);
+
+        // clear input
+        evnt.target.value = '';
+    }
+
+    // function below makes backspace delete tags. Uncomment if we decide this is good UX. 
+    // if (evnt.key === 'Backspace' && evnt.target.value === '') {
+    //     const pills = document.querySelectorAll('#tags-wrap .tag-removable');
+    //     if (pills.length) pills[pills.length - 1].remove();
+    // }
+}
+function removeTag(btn) { 
+    btn.closest('.tag-removable').remove(); 
+}

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -122,6 +122,7 @@ function fmt(type) {
     let selectLen = 0;
 
     switch (type) {
+        
         case 'bold':
             // if text is selected, wrap it. If not, insert placeholder and select it.
             newText = `**${sel || 'bold text'}**`;
@@ -137,6 +138,28 @@ function fmt(type) {
             newText = `~~${sel || 'strikethrough'}~~`;
             cursorOffset = sel ? newText.length : 2 + 13; 
             selectLen = sel ? 0 : 13;
+            break;
+
+        // headings
+        case 'h1':
+            // if the cursor is already at the start of a line, no \n is added. If it's mid-line, a \n is added first to push it onto a new line.
+            // check if start is 0 or if char before is \n to determine this.
+            const prefix1 = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefix1}# ${sel || 'Heading 1'}`;
+            cursorOffset = newText.length;
+            selectLen = sel ? 0 : 9;
+            break;
+        case 'h2':
+            const prefix2 = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefix2}## ${sel || 'Heading 2'}`;
+            cursorOffset = newText.length;
+            selectLen = sel ? 0 : 9;
+            break;
+        case 'h3':
+            const prefix3 = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefix3}### ${sel || 'Heading 3'}`;
+            cursorOffset = newText.length;
+            selectLen = sel ? 0 : 9;
             break;
         default:
             return;

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,0 +1,28 @@
+function setMode(el) {
+    document.querySelectorAll('.view-btn').forEach(b => b.classList.remove('active'));
+    el.classList.add('active');
+}
+
+const noteTitle = document.getElementById('note-title');
+
+
+
+noteTitle.addEventListener('blur', () => {
+    if (noteTitle.textContent.trim() === '') {
+        noteTitle.textContent = 'Enter Note Name...';
+    }
+    noteTitle.scrollLeft = 0;
+});
+
+noteTitle.addEventListener('input', () => {
+    if (noteTitle.textContent.length > 50) {
+        noteTitle.textContent = noteTitle.textContent.substring(0, 50);
+        // keep cursor at end
+        const range = document.createRange();
+        const sel = window.getSelection();
+        range.selectNodeContents(noteTitle);
+        range.collapse(false);
+        sel.removeAllRanges();
+        sel.addRange(range);
+    }
+});

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -79,8 +79,7 @@ function handleResponsiveMode() {
     }
 }
 
-window.addEventListener('resize', handleResponsiveMode);
-handleResponsiveMode();
+
 
 // Markdown preview rendering
 
@@ -89,6 +88,9 @@ marked.setOptions({ breaks: true, gfm: true });
 
 const textarea = document.getElementById('md-input');
 const preview = document.getElementById('md-preview');
+
+window.addEventListener('resize', handleResponsiveMode);
+handleResponsiveMode();
 
 const isMobile = window.innerWidth <= 900;
 document.body.classList.add(isMobile ? 'mode-edit' : 'mode-split');
@@ -102,6 +104,105 @@ renderPreview()
 
 function onEdit() {
     renderPreview();
+}
+
+function insertAtCursor(text) {
+    const element = textarea;
+    const start = element.selectionStart;
+    element.value = element.value.substring(0, start) + text + element.value.substring(element.selectionEnd);
+    element.selectionStart = element.selectionEnd = start + text.length;
+    onEdit();
+}
+
+
+function handleKeys(event) {
+
+    if ((event.ctrlKey || event.metaKey) && event.key === 'b') {
+        event.preventDefault();
+        fmt('bold');
+    }
+    if ((event.ctrlKey || event.metaKey) && event.key === 'i') {
+        event.preventDefault();
+        fmt('italic');
+    }
+
+    // Auto continue lists on enter. 
+    if (event.key === 'Enter') {
+        const cursorPos = textarea.selectionStart;
+        const textBefore = textarea.value.substring(0, cursorPos);
+
+        // used /n to split lines, and used pop to get last (current) line
+        const currentLine = textBefore.split('\n').pop();
+
+        // check if current line is a bullet/num list item
+        const ulMatch = currentLine.match(/^(\s*)-\s/);
+        const olMatch = currentLine.match(/^(\s*)(\d+)\.\s/);
+
+        if (ulMatch) {
+            event.preventDefault();
+            // ulMatch[1] captures (\s*), which is the indent (white spaces)
+            const indent = ulMatch[1];
+
+            // check if line is just a empty dash when enter is pressed
+            if (currentLine.trim() === '-') {
+                // if so, break out of list with a new line (delete the dash and add a new line)
+                const newValue = textarea.value.substring(0, cursorPos - currentLine.length) + '\n' + textarea.value.substring(cursorPos);
+                textarea.value = newValue;
+                textarea.selectionStart = textarea.selectionEnd = cursorPos - currentLine.length + 1;
+                onEdit();
+            } else {
+                // continue bullet list with same indent
+                insertAtCursor(`\n${indent}- `);
+            }
+
+        } else if (olMatch) {
+            event.preventDefault();
+            const indent = olMatch[1];
+
+            if (currentLine.trim() === `${olMatch[2]}.`) {
+                const newValue = textarea.value.substring(0, cursorPos - currentLine.length) + '\n' + textarea.value.substring(cursorPos);
+                textarea.value = newValue;
+                textarea.selectionStart = textarea.selectionEnd = cursorPos - currentLine.length + 1;
+                onEdit();
+            } else {
+                // continue numbered list with same indent
+                insertAtCursor(`\n${indent}1. `);
+            }
+        }
+    }
+
+    // Tab indents and dedents (only lists)
+    if (event.key === 'Tab') {
+
+        event.preventDefault();
+
+        const cursorPos = textarea.selectionStart;
+        const textBefore = textarea.value.substring(0, cursorPos);
+        
+        const currentLine = textBefore.split('\n').pop();
+        const isListLine = currentLine.match(/^(\s*)[-\d]/);
+
+        if (isListLine) {
+            const lineStart = cursorPos - currentLine.length;
+
+            if (event.shiftKey) {
+                // dedent 
+                if (currentLine.startsWith('    ')) {
+                    textarea.value = textarea.value.substring(0, lineStart) + currentLine.substring(4) + textarea.value.substring(cursorPos);
+                    textarea.selectionStart = textarea.selectionEnd = cursorPos - 4;
+                    onEdit();
+                }
+            } else {
+                // indent
+                textarea.value = textarea.value.substring(0, lineStart) + '    ' + currentLine + textarea.value.substring(cursorPos);
+                textarea.selectionStart = textarea.selectionEnd = cursorPos + 4;
+                onEdit();
+            }
+        } else {
+            // not a list line, act as normal tab (insert 4 spaces)
+            insertAtCursor('    ');
+        }
+    }
 }
 
 function fmt(type) {

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -32,6 +32,7 @@ noteTitle.addEventListener('input', () => {
 function setVis(v) {
     document.getElementById('vis-private').classList.toggle('active', v === 'private');
     document.getElementById('vis-public').classList.toggle('active', v === 'public');
+    markUnsaved();
 }
 
 function autoResizeTextarea(element) {
@@ -55,6 +56,7 @@ function handleTag(evnt) {
 
         // clear input
         evnt.target.value = '';
+         markUnsaved();
     }
 
     // function below makes backspace delete tags. Uncomment if we decide this is good UX. 
@@ -65,6 +67,7 @@ function handleTag(evnt) {
 }
 function removeTag(btn) { 
     btn.closest('.tag-removable').remove(); 
+     markUnsaved();
 }
 
 
@@ -371,4 +374,24 @@ function insertTable() {
     // re-render preview and close modal
     onEdit();
     closeTableModal();
+}
+
+
+// Track unsaved changes
+const saveBtn = document.getElementById('btn-save');
+
+function markUnsaved() {
+    saveBtn.classList.add('unsaved');
+}
+
+function markSaved() {
+    saveBtn.classList.remove('unsaved');
+}
+
+noteTitle.addEventListener('input', markUnsaved);
+textarea.addEventListener('input', markUnsaved);
+document.getElementById('note-description').addEventListener('input', markUnsaved);
+
+function saveNote() {
+    markSaved();
 }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -196,6 +196,10 @@ function fmt(type) {
             cursorOffset = sel ? newText.length : prefixCb.length + 4 + 9;
             selectLen = sel ? 0 : 9;
             break;
+
+        case 'table':
+            openTableModal();
+            return;
         // note if --- is added right below a line, md will treat it as h2.
         case 'hr':
             const prefixHr = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
@@ -224,4 +228,147 @@ function fmt(type) {
     el.selectionEnd = start + cursorOffset;
     // re render preview
     onEdit();
+}
+
+
+// Table modal
+const GRID_COLS = 8;
+const GRID_ROWS = 6;
+let selectedCols = 3, selectedRows = 3;
+
+function buildGrid() {
+
+    const picker = document.getElementById('grid-picker');
+    picker.innerHTML = '';
+
+    for (let r = 1; r <= GRID_ROWS; r++) {
+        for (let c = 1; c <= GRID_COLS; c++) {
+            const cell = document.createElement('div');
+            // dataset allows you to set data-* attributes on elements. Used here to store rol and col nums
+            cell.dataset.r = r;
+            cell.dataset.c = c;
+            cell.className = 'grid-cell';
+
+            // () => used to only call the function on click, not immediately. 
+            cell.addEventListener('mouseover', () => hoverGrid(r, c));
+            cell.addEventListener('click', () => { selectedCols = c; selectedRows = r; syncFromGrid(); });
+            picker.appendChild(cell);
+        }
+    }
+    // for default 3x3 to show as active on open
+    highlightGrid(selectedCols, selectedRows);
+}
+
+function hoverGrid(rows, cols) {
+    highlightGrid(cols, rows);
+    // update the "num x num" label on top of the grid
+    document.getElementById('grid-label').textContent = `${cols} × ${rows}`;
+}
+
+function highlightGrid(cols, rows) {
+    // getComputedStyle gets computed CSS styles on the html element (where :root vars live) and getPropertyValue gets the value of the specific CSS variable.
+    const activeCell = getComputedStyle(document.documentElement).getPropertyValue('--grid-cell-active-bg').trim();
+    const inactiveCell = getComputedStyle(document.documentElement).getPropertyValue('--grid-cell-bg').trim();
+    const activeBorder = getComputedStyle(document.documentElement).getPropertyValue('--grid-cell-active-border').trim();
+    const inactiveBorder = getComputedStyle(document.documentElement).getPropertyValue('--editor-box-border').trim();
+
+    document.querySelectorAll('#grid-picker div').forEach(cell => {
+        let isWithinSelection = false;
+
+        // cols and rows are of the cell being hovered
+        if (cell.dataset.c <= cols && cell.dataset.r <= rows) {
+            isWithinSelection = true;
+        }
+
+        if (isWithinSelection) {
+            cell.style.background = activeCell;
+            cell.style.borderColor = activeBorder;
+        } else {
+            cell.style.background = inactiveCell;
+            cell.style.borderColor = inactiveBorder;
+        }
+    });
+}
+
+// called when a cell is clicked. 
+function syncFromGrid() {
+    // sync input fields for row and cols
+    document.getElementById('tbl-cols').value = selectedCols;
+    document.getElementById('tbl-rows').value = selectedRows;
+
+    // sync the preview label between input fields and the insert or cancel buttons.
+    updatePreviewLabel();
+
+    highlightGrid(selectedCols, selectedRows);
+    // sync grid label above grid
+    document.getElementById('grid-label').textContent = `${selectedCols} × ${selectedRows}`;
+}
+
+function syncFromInputs() {
+    // converts input to int, defaults to 1 if empty or invalid. capped at col 50 and row 100.
+    selectedCols = Math.max(1, Math.min(50, parseInt(document.getElementById('tbl-cols').value) || 1));
+    selectedRows = Math.max(1, Math.min(100, parseInt(document.getElementById('tbl-rows').value) || 1));
+
+    // ensure if input is larger than grid it won't break and will just highlight max grid.
+    highlightGrid(Math.min(selectedCols, GRID_COLS), Math.min(selectedRows, GRID_ROWS));
+    document.getElementById('grid-label').textContent = `${selectedCols} × ${selectedRows}`;
+    updatePreviewLabel();
+}
+
+function updatePreviewLabel() {
+    // handles grammar
+    const colWord = selectedCols > 1 ? 'columns' : 'column';
+    const rowWord = selectedRows > 1 ? 'rows' : 'row';
+
+    const label = `${selectedCols} ${colWord} × ${selectedRows} ${rowWord} (+ 1 header row)`;
+    document.getElementById('tbl-preview-label').textContent = label;
+}
+
+function openTableModal() {
+    buildGrid();
+    syncFromGrid();
+    document.getElementById('table-modal-backdrop').style.display = 'block';
+    document.getElementById('table-modal').style.display = 'block';
+}
+
+function closeTableModal() {
+    document.getElementById('table-modal-backdrop').style.display = 'none';
+    document.getElementById('table-modal').style.display = 'none';
+}
+
+function insertTable() {
+    const cols = selectedCols;
+    const rows = selectedRows;
+
+    // build header row: | Column 1 | Column 2 | Column 3 | etc
+    const colNames = Array.from({length: cols}, (_, i) => ` Column ${i + 1} `);
+    const header = '|' + colNames.join('|') + '|';
+
+    // build divider row: |---|---|---|
+    const divider = '|' + Array(cols).fill('---').join('|') + '|';
+
+    // build a single data row: | Cell | Cell | Cell |
+    const dataRow = '|' + Array(cols).fill(' Cell ').join('|') + '|';
+
+    // repeat the data row for however many rows selected
+    const allDataRows = [];
+    for (let i = 0; i < rows; i++) {
+        allDataRows.push(dataRow);
+    }
+
+    // combine everything 
+    const newText = `\n${header}\n${divider}\n${allDataRows.join('\n')}\n\n`;
+
+    // insert at cursor position (this deletes any selected text)
+    const el = textarea;
+    const start = el.selectionStart;
+    el.value = el.value.substring(0, start) + newText + el.value.substring(el.selectionEnd);
+
+    // move cursor to end of inserted table
+    el.focus();
+    el.selectionStart = el.selectionEnd = start + newText.length;
+
+    // re-render preview and close modal
+    onEdit();
+    closeTableModal();
 }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -1,6 +1,7 @@
-function setMode(el) {
+function setMode(mode, element) {
+    document.body.className = 'dashboard-body mode-' + mode;
     document.querySelectorAll('.view-btn').forEach(b => b.classList.remove('active'));
-    el.classList.add('active');
+    element.classList.add('active');
 }
 
 const noteTitle = document.getElementById('note-title');

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -31,3 +31,8 @@ function setVis(v) {
     document.getElementById('vis-private').classList.toggle('active', v === 'private');
     document.getElementById('vis-public').classList.toggle('active', v === 'public');
 }
+
+function autoResizeTextarea(element) {
+    element.style.height = 'auto';
+    element.style.height = element.scrollHeight + 'px';
+}

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -161,6 +161,29 @@ function fmt(type) {
             cursorOffset = newText.length;
             selectLen = sel ? 0 : 9;
             break;
+
+        // lists and quote
+        case 'ul':
+            // same logic for heading
+            const prefixUl = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefixUl}- ${sel || 'List item'}`;
+            cursorOffset = newText.length;
+            selectLen = sel ? 0 : 9;
+            break;
+
+        case 'ol':
+            const prefixOl = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefixOl}1. ${sel || 'List item'}`;
+            cursorOffset = newText.length;
+            selectLen = sel ? 0 : 9;
+            break;
+        case 'quote':
+            const prefixQ = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefixQ}> ${sel || 'Blockquote'}`;
+            cursorOffset = newText.length;
+            selectLen = sel ? 0 : 10;
+            break;
+            
         default:
             return;
     }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -183,12 +183,41 @@ function fmt(type) {
             cursorOffset = newText.length;
             selectLen = sel ? 0 : 10;
             break;
-            
+        
+
+        case 'code':
+            newText = `\`${sel || 'code'}\``;
+            cursorOffset = sel ? newText.length : 1 + 4;
+            selectLen = sel ? 0 : 4;
+            break;
+        case 'codeblock':
+            const prefixCb = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefixCb}\`\`\`\n${sel || 'code here'}\n\`\`\`\n`;
+            cursorOffset = sel ? newText.length : prefixCb.length + 4 + 9;
+            selectLen = sel ? 0 : 9;
+            break;
+        // note if --- is added right below a line, md will treat it as h2.
+        case 'hr':
+            const prefixHr = start === 0 || el.value[start - 1] === '\n' ? '' : '\n';
+            newText = `${prefixHr}***\n`;
+            cursorOffset = newText.length;
+            selectLen = 0;
+            break;
+        case 'link':
+            newText = `[${sel || 'link text'}](url)`;
+            cursorOffset = sel ? newText.length - 5 : 1 + 9;
+            selectLen = sel ? 0 : 9;
+            break;
         default:
             return;
     }
     // rebuild textarea with formatted text inserted
-    el.value = before + newText + after;
+    if (type === 'hr') {
+        // include sel to prevent text deletion for hr
+        el.value = before + newText + sel + after;
+    } else {
+        el.value = before + newText + after;
+    }
     // focus back on textarea and set cursor selection
     el.focus();
     el.selectionStart = start + cursorOffset - selectLen;

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -2,6 +2,7 @@ function setMode(mode, element) {
     document.body.className = 'dashboard-body mode-' + mode;
     document.querySelectorAll('.view-btn').forEach(b => b.classList.remove('active'));
     element.classList.add('active');
+    if (mode !== 'edit') renderPreview();
 }
 
 const noteTitle = document.getElementById('note-title');
@@ -64,4 +65,42 @@ function handleTag(evnt) {
 }
 function removeTag(btn) { 
     btn.closest('.tag-removable').remove(); 
+}
+
+
+function handleResponsiveMode() {
+    const isMobile = window.innerWidth <= 900;
+    if (isMobile) {
+        const previewBtn = document.querySelector('.view-btn[onclick*="preview"]');
+        setMode('preview', previewBtn);
+    }
+}
+
+window.addEventListener('resize', handleResponsiveMode);
+handleResponsiveMode();
+
+// Markdown preview rendering
+
+// breaks treat breaks as br, gfm = github flavoured markdown, adds tables, strikethough etc.
+marked.setOptions({ breaks: true, gfm: true });
+
+const textarea = document.getElementById('md-input');
+const preview = document.getElementById('md-preview');
+
+const isMobile = window.innerWidth <= 900;
+document.body.classList.add(isMobile ? 'mode-edit' : 'mode-split');
+function renderPreview() {
+    preview.innerHTML = marked.parse(textarea.value || '');
+}
+
+
+renderPreview()
+
+
+function onEdit() {
+    renderPreview();
+}
+
+function fmt(type){
+
 }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -26,3 +26,8 @@ noteTitle.addEventListener('input', () => {
         sel.addRange(range);
     }
 });
+
+function setVis(v) {
+    document.getElementById('vis-private').classList.toggle('active', v === 'private');
+    document.getElementById('vis-public').classList.toggle('active', v === 'public');
+}

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -40,7 +40,13 @@
 
       <div class="editor-header">
         <div class="editor-header-left">
-          <div class="dash-greeting">Note Editor</div>
+          <div class="dash-greeting">
+            <a href="index.html" class="back-btn">
+              <i class="bi bi-arrow-left"></i>
+               Note Editor
+            </a> 
+           
+          </div>
           <div class="dash-title editor-title" contenteditable="true" spellcheck="false" id="note-title" >Note Name</div>
         </div>
 

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -69,7 +69,38 @@
       <div class="editor-layout">
 
 
-        <div class="editor-box"></div>
+        <div class="editor-box">
+          <div class="md-toolbar">
+              <button class="tb-btn" data-tip="Bold"><b>B</b></button>
+              <button class="tb-btn" data-tip="Italic"><i>I</i></button>
+              <button class="tb-btn" data-tip="Strikethrough" style="text-decoration:line-through;">S</button>
+
+              <div class="tb-sep"></div>
+
+              <button class="tb-btn" data-tip="Heading 1" >H1</button>
+              <button class="tb-btn" data-tip="Heading 2" >H2</button>
+              <button class="tb-btn" data-tip="Heading 3" >H3</button>
+
+              <div class="tb-sep"></div>
+
+              <button class="tb-btn" data-tip="Bullet list"><i class="bi bi-list-ul"></i></button>
+              <button class="tb-btn" data-tip="Numbered list"><i class="bi bi-list-ol"></i></button>
+              <button class="tb-btn" data-tip="Blockquote"><i class="bi bi-quote"></i></button>
+             
+              <div class="tb-sep"></div>
+
+              <button class="tb-btn" data-tip="Inline code"><i class="bi bi-code"></i></button>
+              <button class="tb-btn" data-tip="Code block"><i class="bi bi-code-square"></i></button>
+              <button class="tb-btn" data-tip="Table"><i class="bi bi-table"></i></button>
+              <button class="tb-btn" data-tip="Horizontal rule"><i class="bi bi-dash-lg"></i></button>
+              
+              <div class="tb-sep"></div>
+
+              <button class="tb-btn" data-tip="Link"><i class="bi bi-link-45deg"></i></button>
+          </div>
+          <div class="editor-pane"></div>
+
+        </div>
 
         <div class="editor-side">
 

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -92,11 +92,11 @@
               <button class="tb-btn" data-tip="Inline code" onclick="fmt('code')"><i class="bi bi-code"></i></button>
               <button class="tb-btn" data-tip="Code block" onclick="fmt('codeblock')"><i class="bi bi-code-square"></i></button>
               <button class="tb-btn" data-tip="Table" onclick="fmt('table')"><i class="bi bi-table"></i></button>
-              <button class="tb-btn" data-tip="Horizontal rule" onclick="fmt('link')"><i class="bi bi-dash-lg"></i></button>
+              <button class="tb-btn" data-tip="Horizontal rule"  onclick="fmt('hr')"><i class="bi bi-dash-lg"></i></button>
               
               <div class="tb-sep"></div>
 
-              <button class="tb-btn" data-tip="Link"><i class="bi bi-link-45deg"></i></button>
+              <button class="tb-btn" data-tip="Link"  onclick="fmt('link')"><i class="bi bi-link-45deg"></i></button>
           </div>
           <div class="editor-pane">
 

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -50,11 +50,11 @@
             <button class="view-btn" onclick="setMode('edit',this)">
               <i class="bi bi-pen"></i> Edit
             </button>
-            <div class="view-toggle-divider"></div>
-            <button class="view-btn active" onclick="setMode('split',this)">
+            <div class="view-toggle-divider" id="divider-left"></div>
+            <button class="view-btn active" onclick="setMode('split',this)" id="btn-split">
               <i class="bi bi-layout-split"></i> Split
             </button>
-            <div class="view-toggle-divider"></div>
+            <div class="view-toggle-divider" id="divider-right"></div>
             <button class="view-btn" onclick="setMode('preview',this)">
               <i class="bi bi-eye"></i> Preview
             </button>

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -90,6 +90,11 @@
 
           <div class="editor-side-card">
             <div class="editor-side-label">Tags:</div>
+            <div class="tags-wrap" id="tags-wrap" onclick="document.getElementById('tag-input').focus()">
+              <span class="note-tag tag-removable">CITS3000 <button class="tag-remove" onclick="removeTag(this)">×</button></span>
+              <span class="note-tag tag-removable">week-2 <button class="tag-remove" onclick="removeTag(this)">×</button></span>
+              <input class="tag-input" id="tag-input" placeholder="Add tag..." onkeydown="handleTag(event)" maxlength="20"/>
+            </div>
           </div>
 
           <div class="editor-side-card">

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -59,7 +59,7 @@
               <i class="bi bi-eye"></i> Preview
             </button>
           </div>
-          <button class="btn-save">Save</button>
+          <button class="btn-save" id="btn-save" onclick="saveNote()">Save</button>
         </div>
       </div>
 
@@ -128,7 +128,7 @@
 
           <div class="editor-side-card">
             <div class="editor-side-label">Description:</div>
-            <textarea class="side-textarea" placeholder="Add a short description..." oninput="autoResizeTextarea(this)"></textarea>
+            <textarea class="side-textarea" placeholder="Add a short description..." oninput="autoResizeTextarea(this)" id="note-description"></textarea>
           </div>
 
           <div class="editor-side-card">

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -47,15 +47,15 @@
 
         <div class="editor-header-right">
           <div class="view-toggle">
-            <button class="view-btn" onclick="setMode(this)">
+            <button class="view-btn" onclick="setMode('edit',this)">
               <i class="bi bi-pen"></i> Edit
             </button>
             <div class="view-toggle-divider"></div>
-            <button class="view-btn active" onclick="setMode(this)">
+            <button class="view-btn active" onclick="setMode('split',this)">
               <i class="bi bi-layout-split"></i> Split
             </button>
             <div class="view-toggle-divider"></div>
-            <button class="view-btn" onclick="setMode(this)">
+            <button class="view-btn" onclick="setMode('preview',this)">
               <i class="bi bi-eye"></i> Preview
             </button>
           </div>
@@ -98,7 +98,19 @@
 
               <button class="tb-btn" data-tip="Link"><i class="bi bi-link-45deg"></i></button>
           </div>
-          <div class="editor-pane"></div>
+          <div class="editor-pane">
+
+              <div class="editor-pane-label write-label">MD Section</div>
+                <textarea class="md-textarea" id="md-input" placeholder="Start writing your note in Markdown..." spellcheck="false"></textarea>
+                
+                <div class="pane-divider"></div>
+
+                <div class="editor-pane-right">
+                  <div class="editor-pane-label preview-label">Preview Section</div>
+                  <div class="md-preview" id="md-preview">Preview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview Section</div>
+              </div>
+
+          </div>
 
         </div>
 

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -75,6 +75,11 @@
 
           <div class="editor-side-card">
             <div class="editor-side-label">Visibility</div>
+            <div class="vis-toggle">
+              <button class="vis-btn active" id="vis-private" onclick="setVis('private')">Private</button>
+              <div class="vis-divider"></div>
+              <button class="vis-btn" id="vis-public" onclick="setVis('public')">Public</button>
+            </div>
           </div>
 
           <div class="editor-side-card">

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -100,13 +100,13 @@
           </div>
           <div class="editor-pane">
 
-              <div class="editor-pane-label write-label">MD Section</div>
+              <!-- <div class="editor-pane-label write-label">MD Section</div> -->
                 <textarea class="md-textarea" id="md-input" placeholder="Start writing your note in Markdown..." spellcheck="false" oninput="onEdit()" onkeydown="handleKeys(event)"></textarea>
                 
                 <div class="pane-divider"></div>
 
                 <div class="editor-pane-right">
-                  <div class="editor-pane-label preview-label">Preview Section</div>
+                  <!-- <div class="editor-pane-label preview-label">Preview Section</div> -->
                   <div class="md-preview" id="md-preview"></div>
               </div>
 
@@ -160,6 +160,33 @@
 
     </div>
   </div>
+
+  <!-- Table modal backdrop -->
+<div id="table-modal-backdrop" onclick="closeTableModal()"></div>
+
+<!-- Table modal -->
+<div id="table-modal">
+  <div class="table-modal-title">Insert Table</div>
+  <div class="table-modal-section">
+    <div class="table-modal-hint">Click to set size — <span id="grid-label">1 × 1</span></div>
+    <div id="grid-picker"></div>
+  </div>
+  <div class="table-modal-inputs">
+    <div class="table-modal-input-group">
+      <div class="table-modal-input-label">Columns</div>
+      <input id="tbl-cols" type="number" min="1" max="20" value="3" oninput="syncFromInputs()"/>
+    </div>
+    <div class="table-modal-input-group">
+      <div class="table-modal-input-label">Rows (excl. header)</div>
+      <input id="tbl-rows" type="number" min="1" max="50" value="3" oninput="syncFromInputs()"/>
+    </div>
+  </div>
+  <div id="tbl-preview-label" class="table-modal-preview">3 columns × 3 rows (+ 1 header row)</div>
+  <div class="table-modal-actions">
+    <button onclick="closeTableModal()" class="table-modal-btn-cancel">Cancel</button>
+    <button onclick="insertTable()" class="table-modal-btn-insert">Insert Table</button>
+  </div>
+</div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="../../static/js/editor.js"></script>

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -71,28 +71,28 @@
 
         <div class="editor-box">
           <div class="md-toolbar">
-              <button class="tb-btn" data-tip="Bold"><b>B</b></button>
-              <button class="tb-btn" data-tip="Italic"><i>I</i></button>
-              <button class="tb-btn" data-tip="Strikethrough" style="text-decoration:line-through;">S</button>
+              <button class="tb-btn" data-tip="Bold" onclick="fmt('bold')"><b>B</b></button>
+              <button class="tb-btn" data-tip="Italic" onclick="fmt('italic')"><i>I</i></button>
+              <button class="tb-btn" data-tip="Strikethrough" onclick="fmt('strike')" style="text-decoration:line-through;">S</button>
 
               <div class="tb-sep"></div>
 
-              <button class="tb-btn" data-tip="Heading 1" >H1</button>
-              <button class="tb-btn" data-tip="Heading 2" >H2</button>
-              <button class="tb-btn" data-tip="Heading 3" >H3</button>
+              <button class="tb-btn" data-tip="Heading 1" onclick="fmt('h1')">H1</button>
+              <button class="tb-btn" data-tip="Heading 2" onclick="fmt('h2')">H2</button>
+              <button class="tb-btn" data-tip="Heading 3" onclick="fmt('h3')">H3</button>
 
               <div class="tb-sep"></div>
 
-              <button class="tb-btn" data-tip="Bullet list"><i class="bi bi-list-ul"></i></button>
-              <button class="tb-btn" data-tip="Numbered list"><i class="bi bi-list-ol"></i></button>
-              <button class="tb-btn" data-tip="Blockquote"><i class="bi bi-quote"></i></button>
-             
+              <button class="tb-btn" data-tip="Bullet list" onclick="fmt('ul')"><i class="bi bi-list-ul"></i></button>
+              <button class="tb-btn" data-tip="Numbered list" onclick="fmt('ol')"><i class="bi bi-list-ol"></i></button>
+              <button class="tb-btn" data-tip="Blockquote" onclick="fmt('quote')"><i class="bi bi-quote"></i></button>
+
               <div class="tb-sep"></div>
 
-              <button class="tb-btn" data-tip="Inline code"><i class="bi bi-code"></i></button>
-              <button class="tb-btn" data-tip="Code block"><i class="bi bi-code-square"></i></button>
-              <button class="tb-btn" data-tip="Table"><i class="bi bi-table"></i></button>
-              <button class="tb-btn" data-tip="Horizontal rule"><i class="bi bi-dash-lg"></i></button>
+              <button class="tb-btn" data-tip="Inline code" onclick="fmt('code')"><i class="bi bi-code"></i></button>
+              <button class="tb-btn" data-tip="Code block" onclick="fmt('codeblock')"><i class="bi bi-code-square"></i></button>
+              <button class="tb-btn" data-tip="Table" onclick="fmt('table')"><i class="bi bi-table"></i></button>
+              <button class="tb-btn" data-tip="Horizontal rule" onclick="fmt('link')"><i class="bi bi-dash-lg"></i></button>
               
               <div class="tb-sep"></div>
 
@@ -101,13 +101,13 @@
           <div class="editor-pane">
 
               <div class="editor-pane-label write-label">MD Section</div>
-                <textarea class="md-textarea" id="md-input" placeholder="Start writing your note in Markdown..." spellcheck="false"></textarea>
+                <textarea class="md-textarea" id="md-input" placeholder="Start writing your note in Markdown..." spellcheck="false" oninput="onEdit()" onkeydown="handleKeys(event)"></textarea>
                 
                 <div class="pane-divider"></div>
 
                 <div class="editor-pane-right">
                   <div class="editor-pane-label preview-label">Preview Section</div>
-                  <div class="md-preview" id="md-preview">Preview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview SectionPreview Section</div>
+                  <div class="md-preview" id="md-preview"></div>
               </div>
 
           </div>
@@ -161,6 +161,7 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="../../static/js/editor.js"></script>
 </body>
 </html>

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -41,7 +41,7 @@
       <div class="editor-header">
         <div class="editor-header-left">
           <div class="dash-greeting">Note Editor</div>
-          <div class="dash-title editor-title" contenteditable="true" spellcheck="false" id="note-title">Note Name</div>
+          <div class="dash-title editor-title" contenteditable="true" spellcheck="false" id="note-title" >Note Name</div>
         </div>
 
 
@@ -75,6 +75,7 @@
 
           <div class="editor-side-card">
             <div class="editor-side-label">Visibility</div>
+            
             <div class="vis-toggle">
               <button class="vis-btn active" id="vis-private" onclick="setVis('private')">Private</button>
               <div class="vis-divider"></div>
@@ -84,6 +85,7 @@
 
           <div class="editor-side-card">
             <div class="editor-side-label">Description:</div>
+            <textarea class="side-textarea" placeholder="Add a short description..." oninput="autoResizeTextarea(this)"></textarea>
           </div>
 
           <div class="editor-side-card">

--- a/templates/dashboard/note_editor.html
+++ b/templates/dashboard/note_editor.html
@@ -1,11 +1,111 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Notetella — Note Editor</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet"/>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet"/>
+  <link rel="stylesheet" href="../../static/css/main.css"/>
+  <link rel="stylesheet" href="../../static/css/dashboard.css"/>
+  <link rel="stylesheet" href="../../static/css/editor.css"/>
 </head>
-<body>
-    this is note_editor
+<body class="dashboard-body">
+
+  <nav class="sidebar">
+    <a href="index.html" class="nav-icon active">
+      <i class="bi bi-house" style="font-size: 20px;"></i>
+    </a>
+    <div class="sidebar-divider"></div> 
+    <a href="../info.html" class="nav-icon">
+      <i class="bi bi-info" style="font-size: 25px;"></i>
+    </a>
+    <div class="sidebar-divider"></div>
+    <a href="../discover/index.html" class="nav-icon">
+      <i class="bi bi-search" style="font-size: 18px;"></i>
+    </a>
+    <div class="sidebar-divider"></div>
+    <a href="../profile.html" class="nav-icon">
+      <i class="bi bi-person" style="font-size: 22px;"></i>
+    </a>
+    <div class="sidebar-divider"></div>
+    <a href="../auth/login.html" class="nav-icon">
+      <i class="bi bi-box-arrow-right" style="font-size: 20px;"></i>
+    </a>
+  </nav>
+
+  <div class="dash-main">
+    <div class="dash-container">
+
+      <div class="editor-header">
+        <div class="editor-header-left">
+          <div class="dash-greeting">Note Editor</div>
+          <div class="dash-title editor-title" contenteditable="true" spellcheck="false" id="note-title">Note Name</div>
+        </div>
+
+
+        <div class="editor-header-right">
+          <div class="view-toggle">
+            <button class="view-btn" onclick="setMode(this)">
+              <i class="bi bi-pen"></i> Edit
+            </button>
+            <div class="view-toggle-divider"></div>
+            <button class="view-btn active" onclick="setMode(this)">
+              <i class="bi bi-layout-split"></i> Split
+            </button>
+            <div class="view-toggle-divider"></div>
+            <button class="view-btn" onclick="setMode(this)">
+              <i class="bi bi-eye"></i> Preview
+            </button>
+          </div>
+          <button class="btn-save">Save</button>
+        </div>
+      </div>
+
+      <div class="dash-divider"></div>
+
+
+      <div class="editor-layout">
+
+
+        <div class="editor-box"></div>
+
+        <div class="editor-side">
+
+          <div class="editor-side-card">
+            <div class="editor-side-label">Visibility</div>
+          </div>
+
+          <div class="editor-side-card">
+            <div class="editor-side-label">Description:</div>
+          </div>
+
+          <div class="editor-side-card">
+            <div class="editor-side-label">Tags:</div>
+          </div>
+
+          <div class="editor-side-card">
+            <div class="editor-side-label">AI Quiz:</div>
+            <button class="btn-quiz" onclick="window.location='../quiz/active.html'">
+              <i class="bi bi-lightning-charge"></i> Generate Quiz
+            </button>
+            <div class="quiz-disclaimer">AI-generated quizzes may not be 100% accurate. Always verify with your course material.</div>
+          </div>
+
+          <div class="editor-side-card">
+            <div class="editor-side-label">Danger Zone:</div>
+            <button class="btn-danger">
+              <i class="bi bi-trash"></i> Delete Note
+            </button>
+          </div>
+
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <script src="../../static/js/editor.js"></script>
 </body>
 </html>

--- a/templates/quiz/active.html
+++ b/templates/quiz/active.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    This is quiz active
+</body>
+</html>


### PR DESCRIPTION
## Summary
Implemented the full note editor page (frontend), including  custom Markdown editor with live split-pane preview, formatting toolbar, and mobile responsive layout.

## Changes
- Note editor skeleton with header, sidebar cards, and view toggle
- Editable note title with 50 character limit and placeholder
- Visibility toggle (Private/Public)
- Description textarea with auto-resize
- Tag input (and ability to remove)
- Markdown toolbar with bold, italic, strikethrough, headings, lists (numbered and un-numbered), blockquote, inline code, code block, horizontal rule, link, and table
- Live Markdown preview using  marked js with full typography styling
- Edit/Split/Preview mode switching
- Visual table grid selection modal
- Mobile responsive layout (≤900px) with scrollable toolbar
- Keyboard shortcuts (Cmd+B, Cmd+I, Tab indent) in editor for better UX
- Save button visual indicator for unsaved changes to Title, Notes, Description, Tags, and Visibility