### PR TITLE
Quiz styling polish

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -108,6 +108,10 @@
     /* Quiz */
     --btn-blue-bg:             rgba(38, 72, 170, 0.22);
     --btn-blue-bg-hover:       rgba(38, 72, 170, 0.35);
+    --btn-green-bg-quiz:       rgba(46, 125, 72, 0.34);
+    --btn-green-bg-quiz-hover: rgba(46, 125, 72, 0.44);
+    --btn-red-bg-quiz:         rgba(176, 59, 59, 0.34);
+    --btn-red-bg-quiz-hover:   rgba(176, 59, 59, 0.44);
     --btn-blue-border:         #6f93ff;
     --btn-blue-color:          #a9bfff;
 }
@@ -174,6 +178,11 @@
     --btn-blue-bg-hover:       rgba(55, 95, 180, 0.18);
     --btn-blue-border:         rgba(55, 95, 180, 0.40);
     --btn-blue-color:          #315FA8;
+
+    --btn-green-bg-quiz:       rgba(100, 255, 150, 0.15);
+    --btn-green-bg-quiz-hover: rgba(100, 255, 150, 0.25);
+    --btn-red-bg-quiz:         rgba(255, 110, 110, 0.15);
+    --btn-red-bg-quiz-hover:   rgba(255, 110, 110, 0.25);
 
     --modal-bg:                rgba(255, 255, 255, 0.80);
     --modal-shadow:            rgba(0, 0, 0, 0.15);

--- a/app/static/css/quiz.css
+++ b/app/static/css/quiz.css
@@ -1,3 +1,5 @@
+/* Header elements */
+
 .quiz-header {
     display: flex;
     align-items: center;
@@ -71,6 +73,17 @@
     background: var(--btn-danger-bg-hover);
 }
 
+.quiz-back-btn {
+    color: var(--text-muted);
+    text-decoration: none;
+    margin-right: 6px;
+    transition: color 0.15s;
+}
+
+.quiz-back-btn:hover {
+    color: var(--text-primary);
+}
+
 .quiz-form {
     display: flex;
     flex-direction: column;
@@ -78,6 +91,283 @@
     min-height: 0;
     width: 100%;
 }
+
+/* Main quiz layout */
+
+.quiz-side-card {
+    background: var(--side-card-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 14px;
+    padding: 14px;
+    flex-shrink: 0;
+}
+
+.quiz-side-label {
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--text-muted);
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--sidebar-divider);
+}
+
+.quiz-active-layout {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.quiz-active-placeholder {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0 8px 0;
+    scroll-behavior: smooth;
+    scrollbar-width: thin;
+    scrollbar-color: var(--sidebar-divider) transparent;
+}
+
+.quiz-active-placeholder::-webkit-scrollbar {
+    width: 3px;
+}
+
+.quiz-active-placeholder::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.quiz-active-placeholder::-webkit-scrollbar-thumb {
+    background: var(--sidebar-divider);
+    border-radius: 2px;
+}
+
+.quiz-active-placeholder::-webkit-scrollbar-thumb:hover {
+    background: var(--editor-box-border);
+}
+
+/* Quiz layout */
+
+.quiz-active-side {
+    width: 220px;
+    flex-shrink: 0;
+    height: 100%;
+    min-height: 0;
+    display: flex;
+}
+
+.quiz-question-list-card {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.quiz-question-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 0 4px 10px 0;
+    overflow-y: auto;
+    min-height: 0;
+    scrollbar-width: thin;
+    scrollbar-color: var(--sidebar-divider) transparent;
+}
+
+.quiz-question-list::-webkit-scrollbar {
+    width: 3px;
+}
+
+.quiz-question-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.quiz-question-list::-webkit-scrollbar-thumb {
+    background: var(--sidebar-divider);
+    border-radius: 2px;
+}
+
+.quiz-question-list::-webkit-scrollbar-thumb:hover {
+    background: var(--editor-box-border);
+}
+
+/* Quiz navigation sidebar */
+
+.quiz-question-item {
+    display: block;
+    width: 100%;
+    border: 0;
+    border-radius: 10px;
+    padding: 10px 10px;
+    background: var(--deck-play-bg);
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.35;
+    text-align: left;
+    text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease;
+    cursor: pointer;
+}
+
+.quiz-question-item .quiz-question-item-full {
+    display: inline;
+}
+
+.quiz-question-item .quiz-question-item-short {
+    display: none;
+}
+
+.quiz-question-item:hover {
+    background: var(--nav-active-bg);
+    color: var(--text-primary);
+}
+
+.quiz-question-item.is-completed {
+    background: var(--btn-blue-bg);
+    color: var(--btn-blue-color);
+}
+
+.quiz-question-item.is-completed:hover {
+    background: var(--btn-blue-bg-hover);
+    color: var(--btn-blue-color);
+}
+
+.quiz-question-item span {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: flex-start;
+    flex-direction: row;
+}
+
+.quiz-question-item span i {
+    flex-shrink: 0;
+}
+
+.quiz-question-item:focus-visible {
+    outline: 2px solid var(--btn-blue-border);
+    outline-offset: 2px;
+}
+
+/* Question Panels */
+
+.quiz-mcq-panel {
+    width: 100%;
+    margin: 0 auto;
+    background: var(--side-card-bg);
+    border: 1px solid var(--editor-box-border);
+    border-radius: 14px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.quiz-mcq-panel:not(:last-child) {
+    margin-bottom: 12px;
+}
+
+.quiz-mcq-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+}
+
+.quiz-mcq-box {
+    width: 100%;
+    min-height: 56px;
+    border-radius: 10px;
+    padding: 10px 12px;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    transition: background 0.15s, border-color 0.15s;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    overflow: visible;
+}
+
+.quiz-mcq-box:hover {
+    background: var(--nav-active-bg);
+    border-color: var(--editor-box-border);
+}
+
+.quiz-question-title {
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+    padding: 0 4px;
+}
+
+.quiz-question-prompt {
+    display: block;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--note-title);
+    margin: 0;
+    padding: 0 4px;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.quiz-option-letter {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 10px;
+    background: var(--input-bg);
+    border: 1px solid var(--input-border);
+    margin: 0;
+    line-height: 1;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--note-title);
+}
+
+.quiz-option-text {
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+    display: block;
+    font-weight: 400;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    text-align: left;
+}
+
+.quiz-mcq-box.quiz-option-selected {
+    background: var(--btn-blue-bg);
+    border-color: var(--btn-blue-border);
+}
+
+.quiz-mcq-box.quiz-option-selected:hover {
+    background: var(--btn-blue-bg-hover);
+    border-color: var(--btn-blue-border);
+}
+
+.quiz-mcq-box.quiz-option-selected .quiz-option-letter {
+    background: var(--btn-blue-bg);
+    border-color: var(--btn-blue-border);
+    color: var(--btn-blue-color);
+}
+
+.quiz-mcq-box.quiz-option-selected .quiz-option-text {
+    color: var(--btn-blue-color);
+}
+
+/* Submit Quiz Modal*/
 
 .quiz-submit-modal-backdrop {
     position: fixed;
@@ -150,701 +440,7 @@
     background: var(--modal-insert-bg-hover);
 }
 
-.quiz-back-btn {
-    color: var(--text-muted);
-    text-decoration: none;
-    margin-right: 6px;
-    transition: color 0.15s;
-}
-
-.quiz-back-btn:hover {
-    color: var(--text-primary);
-}
-
-.quiz-side-card {
-    background: var(--side-card-bg);
-    border: 1px solid var(--editor-box-border);
-    border-radius: 14px;
-    padding: 14px;
-    flex-shrink: 0;
-}
-
-.quiz-side-label {
-    font-size: 11px;
-    font-weight: 400;
-    color: var(--text-muted);
-    margin-bottom: 10px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--sidebar-divider);
-}
-
-.quiz-active-layout {
-    display: flex;
-    flex-direction: row;
-    gap: 16px;
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-}
-
-.quiz-active-placeholder {
-    flex: 1;
-    min-width: 0;
-    min-height: 0;
-    overflow-y: auto;
-    padding: 0 8px 0;
-    scroll-behavior: smooth;
-    scrollbar-width: thin;
-    scrollbar-color: var(--sidebar-divider) transparent;
-}
-
-.quiz-active-placeholder::-webkit-scrollbar {
-    width: 3px;
-}
-
-.quiz-active-placeholder::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.quiz-active-placeholder::-webkit-scrollbar-thumb {
-    background: var(--sidebar-divider);
-    border-radius: 2px;
-}
-
-.quiz-active-placeholder::-webkit-scrollbar-thumb:hover {
-    background: var(--editor-box-border);
-}
-
-.quiz-active-side {
-    width: 220px;
-    flex-shrink: 0;
-    height: 100%;
-    min-height: 0;
-    display: flex;
-}
-
-.quiz-question-list-card {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-}
-
-.quiz-question-list {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding: 0 4px 10px 0;
-    overflow-y: auto;
-    min-height: 0;
-    scrollbar-width: thin;
-    scrollbar-color: var(--sidebar-divider) transparent;
-}
-
-.quiz-question-list::-webkit-scrollbar {
-    width: 3px;
-}
-
-.quiz-question-list::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.quiz-question-list::-webkit-scrollbar-thumb {
-    background: var(--sidebar-divider);
-    border-radius: 2px;
-}
-
-.quiz-question-list::-webkit-scrollbar-thumb:hover {
-    background: var(--editor-box-border);
-}
-
-.quiz-question-item {
-    display: block;
-    width: 100%;
-    border: 0;
-    border-radius: 10px;
-    padding: 10px 10px;
-    background: var(--deck-play-bg);
-    color: var(--text-muted);
-    font-family: inherit;
-    font-size: 11px;
-    font-weight: 400;
-    line-height: 1.35;
-    text-align: left;
-    text-decoration: none;
-    transition: background 0.15s ease, color 0.15s ease;
-    cursor: pointer;
-}
-
-.quiz-question-item .quiz-question-item-full {
-    display: inline;
-}
-
-.quiz-question-item .quiz-question-item-short {
-    display: none;
-}
-
-.quiz-question-item:hover {
-    background: var(--nav-active-bg);
-    color: var(--text-primary);
-}
-
-.quiz-question-item.is-completed {
-    background: var(--btn-blue-bg);
-    color: var(--btn-blue-color);
-}
-
-.quiz-question-item.is-completed:hover {
-    background: var(--btn-blue-bg-hover);
-    color: var(--btn-blue-color);
-}
-
-.quiz-question-item.is-result-correct {
-    background: var(--btn-green-bg-quiz);
-    color: var(--btn-green-color);
-}
-
-.quiz-question-item.is-result-correct:hover {
-    background: var(--btn-green-bg-quiz-hover);
-    color: var(--btn-green-color);
-}
-
-.quiz-question-item.is-result-incorrect {
-    background: var(--btn-red-bg-quiz);
-    color: var(--btn-danger-color);
-}
-
-.quiz-question-item.is-result-incorrect:hover {
-    background: var(--btn-red-bg-quiz-hover);
-    color: var(--btn-danger-color);
-}
-
-.quiz-question-item.is-result-unanswered {
-    /* Use the same neutral styling as the active page list items */
-    background: var(--deck-play-bg);
-    color: var(--text-muted);
-}
-
-.quiz-question-item.is-result-unanswered:hover {
-    background: var(--deck-play-bg-hover);
-    color: var(--text-primary);
-}
-
-.quiz-question-item-summary {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    background: var(--deck-play-bg);
-    color: var(--text-muted);
-}
-
-.quiz-question-item-summary:hover {
-    background: var(--deck-play-bg-hover);
-    color: var(--text-primary);
-}
-
-.quiz-question-item-summary-icon {
-    flex-shrink: 0;
-    line-height: 1;
-}
-
-.quiz-question-item span {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    justify-content: flex-start;
-    flex-direction: row;
-}
-
-.quiz-question-item span i {
-    flex-shrink: 0;
-}
-
-.quiz-results-summary-panel {
-    text-align: center;
-    margin-bottom: 20px;
-}
-
-.quiz-results-summary-panel h2 {
-    margin-bottom: 0px;
-}
-
-.quiz-results-stats {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-}
-
-.quiz-results-score {
-    font-size: 18px;
-    font-weight: 600;
-    line-height: 1.2;
-    margin-bottom: 8px;
-}
-
-.quiz-results-stat {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    line-height: 1.2;
-}
-
-.quiz-results-stat-text {
-    font-size: 14px;
-    font-weight: 500;
-}
-
-.quiz-results-stat-icon {
-    flex-shrink: 0;
-    font-size: 15px;
-}
-
-.quiz-results-stat-correct {
-    color: var(--btn-green-color);
-}
-
-.quiz-results-stat-incorrect {
-    color: var(--btn-danger-color);
-}
-
-.quiz-results-stat-unanswered {
-    color: var(--text-muted);
-}
-
-.quiz-panel-button {
-    padding: 8px 20px;
-    border-radius: 10px;
-    background: var(--btn-login-bg);
-    border: 1px solid var(--input-border);
-    color: var(--text-primary);
-    font-family: var(--font);
-    font-size: 12px;
-    cursor: pointer;
-    transition: background 0.15s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-}
-
-.quiz-panel-button:hover {
-    background: var(--btn-login-hover);
-}
-
-.quiz-panel-buttons-container {
-    display: flex;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 10px;
-}
-
-.quiz-question-item:focus-visible {
-    outline: 2px solid var(--btn-blue-border);
-    outline-offset: 2px;
-}
-
-.quiz-empty-panel {
-    width: 100%;
-    margin: 0 auto;
-    background: var(--note-card-bg);
-    border: 1px solid var(--note-card-border);
-    border-radius: 14px;
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-}
-
-.quiz-mcq-panel {
-    width: 100%;
-    margin: 0 auto;
-    background: var(--side-card-bg);
-    border: 1px solid var(--editor-box-border);
-    border-radius: 14px;
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.quiz-mcq-panel:not(:last-child) {
-    margin-bottom: 12px;
-}
-
-.quiz-mcq-stack {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    width: 100%;
-}
-
-.quiz-mcq-box {
-    width: 100%;
-    min-height: 56px;
-    border-radius: 10px;
-    padding: 10px 12px;
-    background: var(--input-bg);
-    border: 1px solid var(--input-border);
-    transition: background 0.15s, border-color 0.15s;
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    overflow: visible;
-}
-
-.quiz-mcq-box:hover {
-    background: var(--nav-active-bg);
-    border-color: var(--editor-box-border);
-}
-
-.quiz-option-letter {
-    width: 40px;
-    height: 40px;
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 10px;
-    background: var(--input-bg);
-    border: 1px solid var(--input-border);
-    margin: 0;
-    line-height: 1;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--note-title);
-}
-
-.quiz-correct-answer {
-    color: var(--btn-green-color);
-    font-size: 13px;
-    margin-top: 0px;
-    padding-left: 4px;
-}
-
-.quiz-option-text {
-    flex: 1;
-    min-width: 0;
-    margin: 0;
-    display: block;
-    font-weight: 400;
-    line-height: 1.35;
-    overflow-wrap: anywhere;
-    white-space: normal;
-    overflow: visible;
-    text-overflow: clip;
-    text-align: left;
-}
-
-.quiz-results-mode .quiz-mcq-box {
-    cursor: default;
-    pointer-events: none;
-    transition: none;
-}
-
-.quiz-results-mode .quiz-mcq-box:hover {
-    background: var(--input-bg);
-    border-color: var(--input-border);
-    transform: none;
-}
-
-.quiz-mcq-box.quiz-option-selected {
-    background: var(--btn-blue-bg);
-    border-color: var(--btn-blue-border);
-}
-
-.quiz-mcq-box.quiz-option-selected:hover {
-    background: var(--btn-blue-bg-hover);
-    border-color: var(--btn-blue-border);
-}
-
-.quiz-mcq-box.quiz-option-selected .quiz-option-letter {
-    background: var(--btn-blue-bg);
-    border-color: var(--btn-blue-border);
-    color: var(--btn-blue-color);
-}
-
-.quiz-mcq-box.quiz-option-selected .quiz-option-text {
-    color: var(--btn-blue-color);
-}
-
-.quiz-mcq-box.quiz-option-result-correct {
-    background: var(--btn-green-bg);
-    border-color: var(--btn-green-border);
-}
-
-.quiz-mcq-box.quiz-option-result-correct:hover {
-    background: var(--btn-green-bg);
-    border-color: var(--btn-green-border);
-}
-
-.quiz-mcq-box.quiz-option-result-correct .quiz-option-letter {
-    background: var(--btn-green-bg);
-    border-color: var(--btn-green-border);
-    color: var(--btn-green-color);
-}
-
-.quiz-mcq-box.quiz-option-result-correct .quiz-option-text {
-    color: var(--btn-green-color);
-}
-
-.quiz-mcq-box.quiz-option-result-incorrect {
-    background: var(--btn-danger-bg);
-    border-color: var(--btn-danger-border);
-}
-
-.quiz-mcq-box.quiz-option-result-incorrect:hover {
-    background: var(--btn-danger-bg);
-    border-color: var(--btn-danger-border);
-}
-
-.quiz-mcq-box.quiz-option-result-incorrect .quiz-option-letter {
-    background: var(--btn-danger-bg);
-    border-color: var(--btn-danger-border);
-    color: var(--btn-danger-color);
-}
-
-.quiz-mcq-box.quiz-option-result-incorrect .quiz-option-text {
-    color: var(--btn-danger-color);
-}
-
-.quiz-option-icon {
-    width: 24px;
-    height: 24px;
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 20px;
-}
-
-.quiz-option-icon-correct {
-    color: var(--btn-green-color);
-}
-
-.quiz-option-icon-incorrect {
-    color: var(--btn-danger-color);
-}
-
-.quiz-question-title {
-    font-size: 24px;
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0;
-    padding: 0 4px;
-}
-
-.quiz-question-prompt {
-    display: block;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--note-title);
-    margin: 0;
-    padding: 0 4px;
-    white-space: normal;
-    overflow-wrap: anywhere;
-}
-
-/* Results page buttons and modals */
-.quiz-results-btn {
-    padding: 8px 16px;
-    border-radius: 10px;
-    border: none;
-    font-family: var(--font);
-    font-size: 13px;
-    font-weight: 400;
-    cursor: pointer;
-    transition: background 0.15s;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-}
-
-.quiz-results-btn-edit {
-    background: var(--btn-blue-bg);
-    color: var(--btn-blue-color);
-    border: 1px solid var(--btn-blue-border);
-}
-
-.quiz-results-btn-edit:hover {
-    background: var(--btn-blue-bg-hover);
-}
-
-.quiz-results-btn-delete {
-    background: var(--btn-danger-bg);
-    color: var(--btn-danger-color);
-    border: 1px solid var(--btn-danger-border);
-}
-
-.quiz-results-btn-delete:hover {
-    background: var(--btn-danger-bg-hover);
-}
-
-/* Edit Quiz Name Modal */
-.quiz-edit-modal-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: var(--modal-backdrop-bg);
-    backdrop-filter: blur(2px);
-    z-index: 999;
-}
-
-.quiz-edit-modal {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: var(--modal-bg, var(--editor-box-bg));
-    border: 1px solid var(--editor-box-border);
-    border-radius: 14px;
-    padding: 24px;
-    z-index: 1000;
-    max-width: 500px;
-    width: 90%;
-}
-
-.quiz-edit-modal-content {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.quiz-edit-modal-title {
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.quiz-edit-modal-input {
-    padding: 10px 12px;
-    border: 1px solid var(--input-border);
-    border-radius: 8px;
-    background: var(--input-bg);
-    color: var(--text-primary);
-    font-family: var(--font);
-    font-size: 14px;
-    outline: none;
-    transition: border-color 0.15s;
-}
-
-.quiz-edit-modal-input:focus {
-    border-color: var(--btn-blue-border);
-}
-
-.quiz-edit-modal-actions {
-    display: flex;
-    gap: 10px;
-    justify-content: flex-end;
-}
-
-.quiz-edit-modal-btn {
-    padding: 8px 16px;
-    border-radius: 8px;
-    border: none;
-    font-family: var(--font);
-    font-size: 13px;
-    cursor: pointer;
-    transition: background 0.15s;
-}
-
-.quiz-edit-modal-btn-cancel {
-    background: var(--input-bg);
-    color: var(--text-primary);
-    border: 1px solid var(--input-border);
-}
-
-.quiz-edit-modal-btn-cancel:hover {
-    background: var(--editor-box-bg);
-}
-
-.quiz-edit-modal-btn-submit {
-    background: var(--btn-blue-bg);
-    color: var(--btn-blue-color);
-    border: 1px solid var(--btn-blue-border);
-}
-
-.quiz-edit-modal-btn-submit:hover {
-    background: var(--btn-blue-bg-hover);
-}
-
-/* Delete Quiz Modal */
-.quiz-delete-modal-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: var(--modal-backdrop-bg);
-    backdrop-filter: blur(2px);
-    z-index: 999;
-}
-
-.quiz-delete-modal {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: var(--modal-bg, var(--editor-box-bg));
-    border: 1px solid var(--editor-box-border);
-    border-radius: 14px;
-    padding: 24px;
-    z-index: 1000;
-    max-width: 400px;
-    width: 90%;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-.quiz-delete-modal-title {
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.quiz-delete-modal-message {
-    font-size: 14px;
-    color: var(--text-muted);
-}
-
-.quiz-delete-modal-actions {
-    display: flex;
-    gap: 10px;
-    justify-content: flex-end;
-}
-
-.quiz-delete-modal-btn {
-    padding: 8px 16px;
-    border-radius: 8px;
-    border: none;
-    font-family: var(--font);
-    font-size: 13px;
-    cursor: pointer;
-    transition: background 0.15s;
-}
-
-.quiz-delete-modal-btn-cancel {
-    background: var(--input-bg);
-    color: var(--text-primary);
-    border: 1px solid var(--input-border);
-}
-
-.quiz-delete-modal-btn-cancel:hover {
-    background: var(--editor-box-bg);
-}
-
-.quiz-delete-modal-btn-delete {
-    background: var(--btn-danger-bg);
-    color: var(--btn-danger-color);
-    border: 1px solid var(--btn-danger-border);
-}
-
-.quiz-delete-modal-btn-delete:hover {
-    background: var(--btn-danger-bg-hover);
-}
+/* Mobile view */
 
 @media (max-width: 900px) {
     .quiz-header {
@@ -960,24 +556,5 @@
 
     .quiz-question-item .quiz-question-item-short {
         display: inline;
-    }
-
-    .quiz-question-item-summary {
-        justify-content: flex-start;
-    }
-
-    .quiz-question-item-summary .quiz-question-item-full {
-        display: none;
-    }
-
-    .quiz-question-item-summary .quiz-question-item-short {
-        display: inline-flex;
-        width: 100%;
-        align-items: center;
-        justify-content: center;
-    }
-
-    .quiz-question-item-summary-icon {
-        font-size: 18px;
     }
 }

--- a/app/static/css/quiz.css
+++ b/app/static/css/quiz.css
@@ -264,8 +264,8 @@
     border: 0;
     border-radius: 10px;
     padding: 10px 10px;
-    background:var(--dash-bg);
-    color:var( --text-primary);
+    background: var(--deck-play-bg);
+    color: var(--text-muted);
     font-family: inherit;
     font-size: 11px;
     font-weight: 400;
@@ -300,22 +300,22 @@
 }
 
 .quiz-question-item.is-result-correct {
-    background: var(--btn-green-bg);
+    background: var(--btn-green-bg-quiz);
     color: var(--btn-green-color);
 }
 
 .quiz-question-item.is-result-correct:hover {
-    background: var(--btn-green-bg-hover);
+    background: var(--btn-green-bg-quiz-hover);
     color: var(--btn-green-color);
 }
 
 .quiz-question-item.is-result-incorrect {
-    background: var(--btn-danger-bg);
+    background: var(--btn-red-bg-quiz);
     color: var(--btn-danger-color);
 }
 
 .quiz-question-item.is-result-incorrect:hover {
-    background: var(--btn-danger-bg-hover);
+    background: var(--btn-red-bg-quiz-hover);
     color: var(--btn-danger-color);
 }
 

--- a/app/static/css/quiz_results.css
+++ b/app/static/css/quiz_results.css
@@ -1,0 +1,437 @@
+/* Results header buttons */
+
+.quiz-results-btn {
+    padding: 8px 16px;
+    border-radius: 10px;
+    border: none;
+    font-family: var(--font);
+    font-size: 13px;
+    font-weight: 400;
+    cursor: pointer;
+    transition: background 0.15s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.quiz-results-btn-edit {
+    background: var(--btn-blue-bg);
+    color: var(--btn-blue-color);
+    border: 1px solid var(--btn-blue-border);
+}
+
+.quiz-results-btn-edit:hover {
+    background: var(--btn-blue-bg-hover);
+}
+
+.quiz-results-btn-delete {
+    background: var(--btn-danger-bg);
+    color: var(--btn-danger-color);
+    border: 1px solid var(--btn-danger-border);
+}
+
+.quiz-results-btn-delete:hover {
+    background: var(--btn-danger-bg-hover);
+}
+
+/* Results panel */
+
+.quiz-results-summary-panel {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.quiz-results-summary-panel h2 {
+    margin-bottom: 0px;
+}
+
+.quiz-results-stats {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.quiz-results-score {
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 1.2;
+    margin-bottom: 8px;
+}
+
+.quiz-results-stat {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    line-height: 1.2;
+}
+
+.quiz-results-stat-text {
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.quiz-results-stat-icon {
+    flex-shrink: 0;
+    font-size: 15px;
+}
+
+.quiz-results-stat-correct {
+    color: var(--btn-green-color);
+}
+
+.quiz-results-stat-incorrect {
+    color: var(--btn-danger-color);
+}
+
+.quiz-results-stat-unanswered {
+    color: var(--text-muted);
+}
+
+.quiz-panel-button {
+    padding: 8px 20px;
+    border-radius: 10px;
+    background: var(--btn-login-bg);
+    border: 1px solid var(--input-border);
+    color: var(--text-primary);
+    font-family: var(--font);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.quiz-panel-button:hover {
+    background: var(--btn-login-hover);
+}
+
+.quiz-panel-buttons-container {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+/* Question Panels */
+
+.quiz-results-mode .quiz-mcq-box {
+    cursor: default;
+    pointer-events: none;
+    transition: none;
+}
+
+.quiz-results-mode .quiz-mcq-box:hover {
+    background: var(--input-bg);
+    border-color: var(--input-border);
+    transform: none;
+}
+
+.quiz-correct-answer {
+    color: var(--btn-green-color);
+    font-size: 13px;
+    margin-top: 0px;
+    padding-left: 4px;
+}
+
+.quiz-mcq-box.quiz-option-result-correct {
+    background: var(--btn-green-bg);
+    border-color: var(--btn-green-border);
+}
+
+.quiz-mcq-box.quiz-option-result-correct:hover {
+    background: var(--btn-green-bg);
+    border-color: var(--btn-green-border);
+}
+
+.quiz-mcq-box.quiz-option-result-correct .quiz-option-letter {
+    background: var(--btn-green-bg);
+    border-color: var(--btn-green-border);
+    color: var(--btn-green-color);
+}
+
+.quiz-mcq-box.quiz-option-result-correct .quiz-option-text {
+    color: var(--btn-green-color);
+}
+
+.quiz-mcq-box.quiz-option-result-incorrect {
+    background: var(--btn-danger-bg);
+    border-color: var(--btn-danger-border);
+}
+
+.quiz-mcq-box.quiz-option-result-incorrect:hover {
+    background: var(--btn-danger-bg);
+    border-color: var(--btn-danger-border);
+}
+
+.quiz-mcq-box.quiz-option-result-incorrect .quiz-option-letter {
+    background: var(--btn-danger-bg);
+    border-color: var(--btn-danger-border);
+    color: var(--btn-danger-color);
+}
+
+.quiz-mcq-box.quiz-option-result-incorrect .quiz-option-text {
+    color: var(--btn-danger-color);
+}
+
+.quiz-option-icon {
+    width: 24px;
+    height: 24px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 20px;
+}
+
+.quiz-option-icon-correct {
+    color: var(--btn-green-color);
+}
+
+.quiz-option-icon-incorrect {
+    color: var(--btn-danger-color);
+}
+
+/* Quiz navigation sidebar */
+
+.quiz-question-item.is-result-correct {
+    background: var(--btn-green-bg-quiz);
+    color: var(--btn-green-color);
+}
+
+.quiz-question-item.is-result-correct:hover {
+    background: var(--btn-green-bg-quiz-hover);
+    color: var(--btn-green-color);
+}
+
+.quiz-question-item.is-result-incorrect {
+    background: var(--btn-red-bg-quiz);
+    color: var(--btn-danger-color);
+}
+
+.quiz-question-item.is-result-incorrect:hover {
+    background: var(--btn-red-bg-quiz-hover);
+    color: var(--btn-danger-color);
+}
+
+.quiz-question-item.is-result-unanswered {
+    background: var(--deck-play-bg);
+    color: var(--text-muted);
+}
+
+.quiz-question-item.is-result-unanswered:hover {
+    background: var(--deck-play-bg-hover);
+    color: var(--text-primary);
+}
+
+.quiz-question-item-summary {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    background: var(--deck-play-bg);
+    color: var(--text-muted);
+}
+
+.quiz-question-item-summary:hover {
+    background: var(--deck-play-bg-hover);
+    color: var(--text-primary);
+}
+
+.quiz-question-item-summary-icon {
+    flex-shrink: 0;
+    line-height: 1;
+}
+
+/* Quiz Name Modal */
+
+.quiz-edit-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--modal-backdrop-bg);
+    backdrop-filter: blur(2px);
+    z-index: 999;
+}
+
+.quiz-edit-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--modal-bg, var(--editor-box-bg));
+    border: 1px solid var(--editor-box-border);
+    border-radius: 14px;
+    padding: 24px;
+    z-index: 1000;
+    max-width: 500px;
+    width: 90%;
+}
+
+.quiz-edit-modal-content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.quiz-edit-modal-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.quiz-edit-modal-input {
+    padding: 10px 12px;
+    border: 1px solid var(--input-border);
+    border-radius: 8px;
+    background: var(--input-bg);
+    color: var(--text-primary);
+    font-family: var(--font);
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.15s;
+}
+
+.quiz-edit-modal-input:focus {
+    border-color: var(--btn-blue-border);
+}
+
+.quiz-edit-modal-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.quiz-edit-modal-btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    font-family: var(--font);
+    font-size: 13px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.quiz-edit-modal-btn-cancel {
+    background: var(--input-bg);
+    color: var(--text-primary);
+    border: 1px solid var(--input-border);
+}
+
+.quiz-edit-modal-btn-cancel:hover {
+    background: var(--editor-box-bg);
+}
+
+.quiz-edit-modal-btn-submit {
+    background: var(--btn-blue-bg);
+    color: var(--btn-blue-color);
+    border: 1px solid var(--btn-blue-border);
+}
+
+.quiz-edit-modal-btn-submit:hover {
+    background: var(--btn-blue-bg-hover);
+}
+
+/* Delete Quiz Modal */
+
+.quiz-delete-modal-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: var(--modal-backdrop-bg);
+    backdrop-filter: blur(2px);
+    z-index: 999;
+}
+
+.quiz-delete-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--modal-bg, var(--editor-box-bg));
+    border: 1px solid var(--editor-box-border);
+    border-radius: 14px;
+    padding: 24px;
+    z-index: 1000;
+    max-width: 400px;
+    width: 90%;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.quiz-delete-modal-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.quiz-delete-modal-message {
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+.quiz-delete-modal-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.quiz-delete-modal-btn {
+    padding: 8px 16px;
+    border-radius: 8px;
+    border: none;
+    font-family: var(--font);
+    font-size: 13px;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.quiz-delete-modal-btn-cancel {
+    background: var(--input-bg);
+    color: var(--text-primary);
+    border: 1px solid var(--input-border);
+}
+
+.quiz-delete-modal-btn-cancel:hover {
+    background: var(--editor-box-bg);
+}
+
+.quiz-delete-modal-btn-delete {
+    background: var(--btn-danger-bg);
+    color: var(--btn-danger-color);
+    border: 1px solid var(--btn-danger-border);
+}
+
+.quiz-delete-modal-btn-delete:hover {
+    background: var(--btn-danger-bg-hover);
+}
+
+/* Mobile view */
+
+@media (max-width: 900px) {
+    .quiz-question-item-summary {
+        justify-content: flex-start;
+    }
+
+    .quiz-question-item-summary .quiz-question-item-full {
+        display: none;
+    }
+
+    .quiz-question-item-summary .quiz-question-item-short {
+        display: inline-flex;
+        width: 100%;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .quiz-question-item-summary-icon {
+        font-size: 18px;
+    }
+}

--- a/app/templates/intro.html
+++ b/app/templates/intro.html
@@ -11,6 +11,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/flashcard.css') }}"/>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/flashcard_editor.css') }}"/>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/quiz.css') }}"/>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/quiz_results.css') }}"/>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/discover.css') }}"/>
 {% endblock %}
 

--- a/app/templates/quiz/active.html
+++ b/app/templates/quiz/active.html
@@ -86,6 +86,10 @@
     </div>
 </form>
 
+<script src="{{ url_for('static', filename='js/quiz.js') }}"></script>
+{% endblock %}
+
+{% block modals %}
 <div class="quiz-submit-modal-backdrop" id="quiz-submit-modal-backdrop" hidden></div>
 <div class="quiz-submit-modal" id="quiz-submit-modal" role="dialog" aria-modal="true" aria-labelledby="quiz-submit-modal-title" hidden>
     <div class="quiz-submit-modal-title" id="quiz-submit-modal-title">You have unanswered questions. Are you sure you want to submit?</div>
@@ -94,6 +98,4 @@
         <button type="button" class="quiz-submit-modal-btn quiz-submit-modal-btn-submit" id="quiz-submit-modal-submit">Submit</button>
     </div>
 </div>
-
-<script src="{{ url_for('static', filename='js/quiz.js') }}"></script>
-{% endblock %}
+{% endblock %} 

--- a/app/templates/quiz/results.html
+++ b/app/templates/quiz/results.html
@@ -5,6 +5,7 @@
 {% block styles %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}"/>
 <link rel="stylesheet" href="{{ url_for('static', filename='css/quiz.css') }}"/>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/quiz_results.css') }}"/>
 {% endblock %}
 
 {% block page_content %}

--- a/app/templates/quiz/results.html
+++ b/app/templates/quiz/results.html
@@ -171,6 +171,10 @@
     </div>
 </div>
 
+<script src="{{ url_for('static', filename='js/quiz_results.js') }}"></script>
+{% endblock %}
+
+{% block modals %}
 <!-- Edit Quiz Name Modal -->
 <div class="quiz-edit-modal-backdrop" id="quiz-edit-modal-backdrop" hidden></div>
 <div class="quiz-edit-modal" id="quiz-edit-modal" role="dialog" aria-modal="true" aria-labelledby="quiz-edit-modal-title" hidden>
@@ -200,6 +204,4 @@
         <button type="button" class="quiz-delete-modal-btn quiz-delete-modal-btn-delete" id="quiz-delete-modal-confirm">Delete</button>
     </div>
 </div>
-
-<script src="{{ url_for('static', filename='js/quiz_results.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Resolves #109 

Fixes the background blur of modals being super bright on quiz active and results
Also adjusts the styling of quiz navigation items for quiz active and results (introduced new color vars for correct and incorrect item fills, both dark and light mode)
Also features a reorganizing split of quiz.css into a main quiz.css and a quiz_results.css