### PR TITLE
fix: mark note unsaved after toolbar edits

### DIFF
--- a/app/static/js/note_editor.js
+++ b/app/static/js/note_editor.js
@@ -286,6 +286,7 @@ function fmt(type) {
 
     // re render preview
     onEdit();
+    markUnsaved();
 }
 
 

--- a/app/static/js/note_table.js
+++ b/app/static/js/note_table.js
@@ -136,6 +136,7 @@ function insertTable() {
 
     // re-render preview and close modal
     onEdit();
+    markUnsaved();
     closeTableModal();
 }
 


### PR DESCRIPTION
## Summary
Pure UI change for note editor. Fixed bug where using tool bar does not change the colour of save button from green to red.